### PR TITLE
Update submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "scripts/firmware"]
 	path = scripts/firmware
-	url = git://srobo.org/boards/firmware.git
+	url = git://git.studentrobotics.org/boards/firmware.git


### PR DESCRIPTION
srobo.org -> git.studentrobotics.org, because srobo.org doesn't resolve at the moment.

Related: https://github.com/srobo/tasks/issues/179 for moving
the submodule repository from cgit to github.