### PR TITLE
Update submodule url to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "scripts/firmware"]
 	path = scripts/firmware
-	url = git://git.studentrobotics.org/boards/firmware.git
+	url = https://github.com/srobo-legacy/boards-firmware.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "scripts/firmware"]
 	path = scripts/firmware
-	url = https://github.com/srobo-legacy/boards-firmware.git
+	url = https://github.com/srobo/boards-firmware.git


### PR DESCRIPTION
For the moment this is the archived srobo-legacy repo, however once that moves to the main srobo org we should update this link. (When it does move GitHub will redirect such that this still works,
so this change is fairly resilient).